### PR TITLE
ci: Enable Experimental Builds on Feature Branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - "feature/**"
   pull_request:
     types:
       - opened


### PR DESCRIPTION
Updates the release workflow to trigger on `feature/**` branches.

Releases a docker image tagged as experimental when pushing to a feature branch.
Required to support the continuous experimentation setup in the `operation` repository.