### PR TITLE
Change release workflow behaviour to only release master and experimental branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,12 @@
 name: Frontend Release
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
-      - "feature/**"
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-  workflow_dispatch:
+      - experimental
+  
 
 jobs:
   release:
@@ -50,11 +46,11 @@ jobs:
             VERSION="$MAJOR.$MINOR.$PATCH"
             TAGS="-t $IMAGE:$VERSION -t $IMAGE:stable -t $IMAGE:latest"
             
-          elif [[ "$BRANCH" == feature/* ]] || [[ "$BRANCH" == experiment/* ]]; then
+          elif [[ "$BRANCH" == "experimental" ]]; then
             # Feature/experiment branch: append branch name + SHA, tag as experimental
             BRANCH_SLUG=$(echo "$BRANCH" | sed 's|/|-|g' | tr '[:upper:]' '[:lower:]')
             VERSION="${BASE_VERSION}-${BRANCH_SLUG}-${SHORT_SHA}"
-            TAGS="-t $IMAGE:$VERSION -t $IMAGE:experimental -t $IMAGE:latest"
+            TAGS="-t $IMAGE:$VERSION -t $IMAGE:experimental"
             
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
             # PR build: append pr number + SHA, no semantic tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,16 +52,10 @@ jobs:
             VERSION="${BASE_VERSION}-${BRANCH_SLUG}-${SHORT_SHA}"
             TAGS="-t $IMAGE:$VERSION -t $IMAGE:experimental"
             
-          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            # PR build: append pr number + SHA, no semantic tags
-            PR_NUM="${{ github.event.pull_request.number }}"
-            VERSION="${BASE_VERSION}-pr-${PR_NUM}-${SHORT_SHA}"
-            TAGS="-t $IMAGE:$VERSION"
-            
           else
             # Other branches: just version + SHA
             VERSION="${BASE_VERSION}-${SHORT_SHA}"
-            TAGS="-t $IMAGE:$VERSION -t $IMAGE:latest"
+            TAGS="-t $IMAGE:$VERSION"
           fi
           
           echo "VERSION=$VERSION" >> $GITHUB_ENV


### PR DESCRIPTION
# Changes
- Add creating releases upon pushing to the `experimental` branch
- Remove creating releases upon pushing to the `feature/*` or `experiment/*` branches
- Releases tagged with `experimental` can no longer also be tagged with `latest`
- Only queue release when either `master` or `experimental` branch are updated or manual dispatch